### PR TITLE
ベーシック認証導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
@@ -6,4 +7,13 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :encrypted_password, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
   end
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+
 end


### PR DESCRIPTION
# What
ベーシック認証の導入

# Why
誤ってアクセスしたユーザーに誤解を生むことがないように、Basic認証を導入して閲覧できるユーザーを制限するため